### PR TITLE
Fix customCSS updates in theme handling

### DIFF
--- a/src/app/api/link-pages/[id]/theme/route.ts
+++ b/src/app/api/link-pages/[id]/theme/route.ts
@@ -28,14 +28,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         },
       }
     );
-    
+
     // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const pageId = resolvedParams.id;
@@ -43,18 +43,21 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // Get link page with theme configuration
     const { data: linkPage, error } = await supabase
       .from('link_pages')
-      .select(`
+      .select(
+        `
         theme_config,
         background_config,
         typography_config,
         layout_config,
         brand_config,
+        custom_css,
         user_theme_id,
         user_theme:user_themes(
           custom_config,
           theme:themes(config)
         )
-      `)
+      `
+      )
       .eq('id', pageId)
       .eq('user_id', user.id)
       .single();
@@ -69,7 +72,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Merge theme configurations in order of priority:
     // 1. Base theme config (lowest priority)
-    // 2. User theme customizations 
+    // 2. User theme customizations
     // 3. Page-specific theme config (highest priority)
     let mergedConfig: any = null;
 
@@ -80,7 +83,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Apply user theme customizations
     if (linkPage.user_theme?.custom_config) {
-      mergedConfig = mergedConfig 
+      mergedConfig = mergedConfig
         ? { ...mergedConfig, ...linkPage.user_theme.custom_config }
         : linkPage.user_theme.custom_config;
     }
@@ -88,23 +91,33 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // Apply page-specific configurations
     const pageConfigs = {
       ...(linkPage.theme_config || {}),
-      ...(linkPage.background_config ? { background: linkPage.background_config } : {}),
-      ...(linkPage.typography_config ? { typography: linkPage.typography_config } : {}),
+      ...(linkPage.background_config
+        ? { background: linkPage.background_config }
+        : {}),
+      ...(linkPage.typography_config
+        ? { typography: linkPage.typography_config }
+        : {}),
       ...(linkPage.layout_config ? { layout: linkPage.layout_config } : {}),
-      ...(linkPage.brand_config ? { brand: linkPage.brand_config } : {})
+      ...(linkPage.brand_config ? { brand: linkPage.brand_config } : {}),
     };
 
     if (Object.keys(pageConfigs).length > 0) {
-      mergedConfig = mergedConfig 
+      mergedConfig = mergedConfig
         ? { ...mergedConfig, ...pageConfigs }
         : pageConfigs;
     }
 
+    const customCSS =
+      (linkPage.theme_config as any)?.customCSS ?? linkPage.custom_css;
+
+    if (customCSS) {
+      mergedConfig = { ...(mergedConfig || {}), customCSS };
+    }
+
     return NextResponse.json({
       data: mergedConfig,
-      success: true
+      success: true,
     });
-
   } catch (error) {
     console.error('Error in GET /api/link-pages/[id]/theme:', error);
     return NextResponse.json(
@@ -130,35 +143,38 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         },
       }
     );
-    
+
     // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const pageId = resolvedParams.id;
     const body = await request.json();
-    
+
     console.log('Received theme config body:', JSON.stringify(body, null, 2));
-    
+
     try {
       const validatedData = ThemeConfigSchema.parse(body);
       console.log('Theme config validation successful:', validatedData);
     } catch (validationError) {
       console.error('Theme config validation failed:', validationError);
       return NextResponse.json(
-        { 
+        {
           error: 'Invalid theme configuration',
-          details: validationError instanceof z.ZodError ? validationError.errors : validationError
+          details:
+            validationError instanceof z.ZodError
+              ? validationError.errors
+              : validationError,
         },
         { status: 400 }
       );
     }
-    
+
     const validatedData = ThemeConfigSchema.parse(body);
 
     // Verify user owns this link page
@@ -178,7 +194,7 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
 
     // Update the link page with new theme configuration
     const updateData: any = {
-      updated_at: new Date().toISOString()
+      updated_at: new Date().toISOString(),
     };
 
     // Store the complete theme config
@@ -202,6 +218,9 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     if (validatedData.brand) {
       updateData.brand_config = validatedData.brand;
     }
+    if (validatedData.customCSS) {
+      updateData.custom_css = validatedData.customCSS;
+    }
 
     const { data: updatedPage, error: updateError } = await supabase
       .from('link_pages')
@@ -221,9 +240,8 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
 
     return NextResponse.json({
       data: updatedPage,
-      success: true
+      success: true,
     });
-
   } catch (error) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(
@@ -255,14 +273,14 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         },
       }
     );
-    
+
     // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const pageId = params.id;
@@ -289,7 +307,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         .select('id')
         .eq('id', userThemeId)
         .eq('user_id', user.id)
-        .single()
+        .single(),
     ]);
 
     if (pageResult.error || !pageResult.data) {
@@ -311,7 +329,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       .from('link_pages')
       .update({
         user_theme_id: userThemeId,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
       .eq('id', pageId)
       .eq('user_id', user.id)
@@ -328,9 +346,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     return NextResponse.json({
       data: updatedPage,
-      success: true
+      success: true,
     });
-
   } catch (error) {
     console.error('Error in PATCH /api/link-pages/[id]/theme:', error);
     return NextResponse.json(
@@ -338,4 +355,4 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       { status: 500 }
     );
   }
-} 
+}

--- a/src/hooks/useThemeCustomizer.ts
+++ b/src/hooks/useThemeCustomizer.ts
@@ -1,18 +1,18 @@
 import { useState, useEffect, useCallback } from 'react';
-import { 
-  getLinkPageThemeConfig, 
-  updateLinkPageThemeConfig, 
-  createUserTheme
+import {
+  getLinkPageThemeConfig,
+  updateLinkPageThemeConfig,
+  createUserTheme,
 } from '@/lib/api/themes';
 import { PREDEFINED_THEMES } from '@/constants/themePresets';
-import type { 
-  ThemeConfig, 
-  HeaderBlockConfig, 
-  LinkStyleConfig, 
+import type {
+  ThemeConfig,
+  HeaderBlockConfig,
+  LinkStyleConfig,
   PageBlock,
   BackgroundConfig,
   TypographyConfig,
-  BrandAssets
+  BrandAssets,
 } from '@/types';
 
 interface UseThemeCustomizerProps {
@@ -20,23 +20,26 @@ interface UseThemeCustomizerProps {
   onThemeChange?: (themeConfig: ThemeConfig) => void;
 }
 
-export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustomizerProps) {
+export function useThemeCustomizer({
+  linkPageId,
+  onThemeChange,
+}: UseThemeCustomizerProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-  
+
   // Theme configuration state
   const [themeConfig, setThemeConfig] = useState<ThemeConfig | null>(null);
   const [backgroundConfig, setBackgroundConfig] = useState<BackgroundConfig>({
     type: 'solid',
-    value: '#ffffff'
+    value: '#ffffff',
   });
   const [typographyConfig, setTypographyConfig] = useState<TypographyConfig>({
     fontFamily: 'Inter',
     title: { size: '3xl', weight: '700', color: '#1f2937' },
     description: { size: 'lg', color: '#6b7280' },
-    links: { size: 'base', weight: '500', color: '#374151' }
+    links: { size: 'base', weight: '500', color: '#374151' },
   });
   const [brandAssets, setBrandAssets] = useState<BrandAssets>({
     colors: {
@@ -44,16 +47,16 @@ export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustom
       secondary: '#ec4899',
       accent: '#3b82f6',
       background: '#ffffff',
-      text: '#1f2937'
+      text: '#1f2937',
     },
-    colorPalettes: []
+    colorPalettes: [],
   });
   const [customCSS, setCustomCSS] = useState('');
-  
+
   // New block-based configuration state
   const [headerConfig, setHeaderConfig] = useState<HeaderBlockConfig>({
     type: 'none',
-    height: 'medium'
+    height: 'medium',
   });
   const [linkStyleConfig, setLinkStyleConfig] = useState<LinkStyleConfig>({
     backgroundColor: '#ffffff',
@@ -65,11 +68,11 @@ export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustom
     shadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1)',
     spacing: { padding: '16px', margin: '8px' },
     typography: { size: '16px', weight: '500' },
-    icon: { show: false, position: 'left', size: '20px' }
+    icon: { show: false, position: 'left', size: '20px' },
   });
   const [pageBlocks, setPageBlocks] = useState<PageBlock[]>([
     { id: 'profile', type: 'profile', enabled: true, order: 0, config: {} },
-    { id: 'links', type: 'links', enabled: true, order: 1, config: {} }
+    { id: 'links', type: 'links', enabled: true, order: 1, config: {} },
   ]);
 
   // Load current theme configuration
@@ -81,11 +84,11 @@ export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustom
     try {
       setIsLoading(true);
       const response = await getLinkPageThemeConfig(linkPageId);
-      
+
       if (response.success && response.data) {
         const config = response.data;
         setThemeConfig(config);
-        
+
         // Extract individual configurations
         if (config.background) {
           setBackgroundConfig(config.background);
@@ -114,144 +117,179 @@ export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustom
     }
   };
 
-  const handlePresetSelect = useCallback((preset: typeof PREDEFINED_THEMES[0]) => {
-    const config = preset.config;
-    
-    // Update all configurations
-    if (config.background) {
-      setBackgroundConfig(config.background);
-    }
-    if (config.typography) {
-      setTypographyConfig(config.typography);
-    }
-    if (config.header) {
-      setHeaderConfig(config.header);
-    }
-    if (config.links) {
-      setLinkStyleConfig(config.links);
-    }
-    if (config.layout?.blocks) {
-      setPageBlocks(config.layout.blocks);
-    }
-    
-    // Merge into theme config
-    const newThemeConfig: ThemeConfig = {
-      ...themeConfig,
-      ...config
-    };
-    
-    setThemeConfig(newThemeConfig);
-    setHasUnsavedChanges(true);
-    
-    if (onThemeChange) {
-      onThemeChange(newThemeConfig);
-    }
-  }, [themeConfig, onThemeChange]);
+  const handlePresetSelect = useCallback(
+    (preset: (typeof PREDEFINED_THEMES)[0]) => {
+      const config = preset.config;
 
-  const handleBackgroundChange = useCallback((config: BackgroundConfig) => {
-    setBackgroundConfig(config);
-    
-    const newThemeConfig: ThemeConfig = {
-      ...themeConfig,
-      background: config
-    };
-    
-    setThemeConfig(newThemeConfig);
-    setHasUnsavedChanges(true);
-    
-    if (onThemeChange) {
-      onThemeChange(newThemeConfig);
-    }
-  }, [themeConfig, onThemeChange]);
-
-  const handleTypographyChange = useCallback((config: TypographyConfig) => {
-    setTypographyConfig(config);
-    
-    const newThemeConfig: ThemeConfig = {
-      ...themeConfig,
-      typography: config
-    };
-    
-    setThemeConfig(newThemeConfig);
-    setHasUnsavedChanges(true);
-    
-    if (onThemeChange) {
-      onThemeChange(newThemeConfig);
-    }
-  }, [themeConfig, onThemeChange]);
-
-  const handleBrandAssetsChange = useCallback((assets: BrandAssets) => {
-    setBrandAssets(assets);
-    
-    const newThemeConfig: ThemeConfig = {
-      ...themeConfig,
-      brand: assets
-    };
-    
-    setThemeConfig(newThemeConfig);
-    setHasUnsavedChanges(true);
-    
-    if (onThemeChange) {
-      onThemeChange(newThemeConfig);
-    }
-  }, [themeConfig, onThemeChange]);
-
-  const handleCSSChange = useCallback((css: string) => {
-    setCustomCSS(css);
-    setHasUnsavedChanges(true);
-  }, []);
-
-  const handleHeaderChange = useCallback((config: HeaderBlockConfig) => {
-    setHeaderConfig(config);
-    
-    const newThemeConfig: ThemeConfig = {
-      ...themeConfig,
-      header: config
-    };
-    
-    setThemeConfig(newThemeConfig);
-    setHasUnsavedChanges(true);
-    
-    if (onThemeChange) {
-      onThemeChange(newThemeConfig);
-    }
-  }, [themeConfig, onThemeChange]);
-
-  const handleLinkStyleChange = useCallback((config: LinkStyleConfig) => {
-    setLinkStyleConfig(config);
-    
-    const newThemeConfig: ThemeConfig = {
-      ...themeConfig,
-      links: config
-    };
-    
-    setThemeConfig(newThemeConfig);
-    setHasUnsavedChanges(true);
-    
-    if (onThemeChange) {
-      onThemeChange(newThemeConfig);
-    }
-  }, [themeConfig, onThemeChange]);
-
-  const handleBlocksChange = useCallback((blocks: PageBlock[]) => {
-    setPageBlocks(blocks);
-    
-    const newThemeConfig: ThemeConfig = {
-      ...themeConfig,
-      layout: {
-        ...themeConfig?.layout,
-        type: 'blocks',
-        blocks
+      // Update all configurations
+      if (config.background) {
+        setBackgroundConfig(config.background);
       }
-    };
-    
-    setThemeConfig(newThemeConfig);
-    setHasUnsavedChanges(true);
-    
-    if (onThemeChange) {
-      onThemeChange(newThemeConfig);
-    }
-  }, [themeConfig, onThemeChange]);
+      if (config.typography) {
+        setTypographyConfig(config.typography);
+      }
+      if (config.header) {
+        setHeaderConfig(config.header);
+      }
+      if (config.links) {
+        setLinkStyleConfig(config.links);
+      }
+      if (config.layout?.blocks) {
+        setPageBlocks(config.layout.blocks);
+      }
+
+      // Merge into theme config
+      const newThemeConfig: ThemeConfig = {
+        ...themeConfig,
+        ...config,
+      };
+
+      setThemeConfig(newThemeConfig);
+      setHasUnsavedChanges(true);
+
+      if (onThemeChange) {
+        onThemeChange(newThemeConfig);
+      }
+    },
+    [themeConfig, onThemeChange]
+  );
+
+  const handleBackgroundChange = useCallback(
+    (config: BackgroundConfig) => {
+      setBackgroundConfig(config);
+
+      const newThemeConfig: ThemeConfig = {
+        ...themeConfig,
+        background: config,
+      };
+
+      setThemeConfig(newThemeConfig);
+      setHasUnsavedChanges(true);
+
+      if (onThemeChange) {
+        onThemeChange(newThemeConfig);
+      }
+    },
+    [themeConfig, onThemeChange]
+  );
+
+  const handleTypographyChange = useCallback(
+    (config: TypographyConfig) => {
+      setTypographyConfig(config);
+
+      const newThemeConfig: ThemeConfig = {
+        ...themeConfig,
+        typography: config,
+      };
+
+      setThemeConfig(newThemeConfig);
+      setHasUnsavedChanges(true);
+
+      if (onThemeChange) {
+        onThemeChange(newThemeConfig);
+      }
+    },
+    [themeConfig, onThemeChange]
+  );
+
+  const handleBrandAssetsChange = useCallback(
+    (assets: BrandAssets) => {
+      setBrandAssets(assets);
+
+      const newThemeConfig: ThemeConfig = {
+        ...themeConfig,
+        brand: assets,
+      };
+
+      setThemeConfig(newThemeConfig);
+      setHasUnsavedChanges(true);
+
+      if (onThemeChange) {
+        onThemeChange(newThemeConfig);
+      }
+    },
+    [themeConfig, onThemeChange]
+  );
+
+  const handleCSSChange = useCallback(
+    (css: string) => {
+      setCustomCSS(css);
+
+      const newThemeConfig: ThemeConfig = {
+        ...themeConfig,
+        customCSS: css,
+      };
+
+      setThemeConfig(newThemeConfig);
+      setHasUnsavedChanges(true);
+
+      if (onThemeChange) {
+        onThemeChange(newThemeConfig);
+      }
+    },
+    [themeConfig, onThemeChange]
+  );
+
+  const handleHeaderChange = useCallback(
+    (config: HeaderBlockConfig) => {
+      setHeaderConfig(config);
+
+      const newThemeConfig: ThemeConfig = {
+        ...themeConfig,
+        header: config,
+      };
+
+      setThemeConfig(newThemeConfig);
+      setHasUnsavedChanges(true);
+
+      if (onThemeChange) {
+        onThemeChange(newThemeConfig);
+      }
+    },
+    [themeConfig, onThemeChange]
+  );
+
+  const handleLinkStyleChange = useCallback(
+    (config: LinkStyleConfig) => {
+      setLinkStyleConfig(config);
+
+      const newThemeConfig: ThemeConfig = {
+        ...themeConfig,
+        links: config,
+      };
+
+      setThemeConfig(newThemeConfig);
+      setHasUnsavedChanges(true);
+
+      if (onThemeChange) {
+        onThemeChange(newThemeConfig);
+      }
+    },
+    [themeConfig, onThemeChange]
+  );
+
+  const handleBlocksChange = useCallback(
+    (blocks: PageBlock[]) => {
+      setPageBlocks(blocks);
+
+      const newThemeConfig: ThemeConfig = {
+        ...themeConfig,
+        layout: {
+          ...themeConfig?.layout,
+          type: 'blocks',
+          blocks,
+        },
+      };
+
+      setThemeConfig(newThemeConfig);
+      setHasUnsavedChanges(true);
+
+      if (onThemeChange) {
+        onThemeChange(newThemeConfig);
+      }
+    },
+    [themeConfig, onThemeChange]
+  );
 
   const saveTheme = async () => {
     if (!themeConfig) return;
@@ -259,7 +297,7 @@ export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustom
     try {
       setIsSaving(true);
       const response = await updateLinkPageThemeConfig(linkPageId, themeConfig);
-      
+
       if (response.success) {
         setHasUnsavedChanges(false);
         setError(null);
@@ -284,9 +322,9 @@ export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustom
       setIsSaving(true);
       const response = await createUserTheme({
         name: themeName,
-        custom_config: themeConfig
+        custom_config: themeConfig,
       });
-      
+
       if (response.success) {
         setError(null);
         // Optionally show success message
@@ -315,7 +353,7 @@ export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustom
     headerConfig,
     linkStyleConfig,
     pageBlocks,
-    
+
     // Actions
     handlePresetSelect,
     handleBackgroundChange,
@@ -327,6 +365,6 @@ export function useThemeCustomizer({ linkPageId, onThemeChange }: UseThemeCustom
     handleBlocksChange,
     saveTheme,
     saveAsNewTheme,
-    loadThemeConfig
+    loadThemeConfig,
   };
 }


### PR DESCRIPTION
## Summary
- update CSS handler to sync themeConfig and notify parent
- persist custom CSS when updating theme config
- include custom CSS in GET `/api/link-pages/[id]/theme`

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check` *(fails: TS2554 etc.)*
- `npm run test:e2e` *(fails: multiple tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_688cd958ff1c8325b4bdab22670332e7