### PR TITLE
Fix cookie handling for theme API

### DIFF
--- a/src/app/api/link-pages/[id]/theme/route.ts
+++ b/src/app/api/link-pages/[id]/theme/route.ts
@@ -15,8 +15,7 @@ interface RouteParams {
 // GET /api/link-pages/[id]/theme - Get theme configuration for a link page
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
-    const cookieStore = await cookies();
-    const resolvedParams = await params;
+    const cookieStore = cookies();
     const supabase = createServerClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -28,22 +27,23 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         },
       }
     );
-    
+
     // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const pageId = resolvedParams.id;
+    const pageId = params.id;
 
     // Get link page with theme configuration
     const { data: linkPage, error } = await supabase
       .from('link_pages')
-      .select(`
+      .select(
+        `
         theme_config,
         background_config,
         typography_config,
@@ -54,7 +54,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
           custom_config,
           theme:themes(config)
         )
-      `)
+      `
+      )
       .eq('id', pageId)
       .eq('user_id', user.id)
       .single();
@@ -69,8 +70,9 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Merge theme configurations in order of priority:
     // 1. Base theme config (lowest priority)
-    // 2. User theme customizations 
+    // 2. User theme customizations
     // 3. Page-specific theme config (highest priority)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let mergedConfig: any = null;
 
     // Start with base theme if available
@@ -80,7 +82,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // Apply user theme customizations
     if (linkPage.user_theme?.custom_config) {
-      mergedConfig = mergedConfig 
+      mergedConfig = mergedConfig
         ? { ...mergedConfig, ...linkPage.user_theme.custom_config }
         : linkPage.user_theme.custom_config;
     }
@@ -88,23 +90,26 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     // Apply page-specific configurations
     const pageConfigs = {
       ...(linkPage.theme_config || {}),
-      ...(linkPage.background_config ? { background: linkPage.background_config } : {}),
-      ...(linkPage.typography_config ? { typography: linkPage.typography_config } : {}),
+      ...(linkPage.background_config
+        ? { background: linkPage.background_config }
+        : {}),
+      ...(linkPage.typography_config
+        ? { typography: linkPage.typography_config }
+        : {}),
       ...(linkPage.layout_config ? { layout: linkPage.layout_config } : {}),
-      ...(linkPage.brand_config ? { brand: linkPage.brand_config } : {})
+      ...(linkPage.brand_config ? { brand: linkPage.brand_config } : {}),
     };
 
     if (Object.keys(pageConfigs).length > 0) {
-      mergedConfig = mergedConfig 
+      mergedConfig = mergedConfig
         ? { ...mergedConfig, ...pageConfigs }
         : pageConfigs;
     }
 
     return NextResponse.json({
       data: mergedConfig,
-      success: true
+      success: true,
     });
-
   } catch (error) {
     console.error('Error in GET /api/link-pages/[id]/theme:', error);
     return NextResponse.json(
@@ -117,8 +122,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 // PUT /api/link-pages/[id]/theme - Update theme configuration for a link page
 export async function PUT(request: NextRequest, { params }: RouteParams) {
   try {
-    const cookieStore = await cookies();
-    const resolvedParams = await params;
+    const cookieStore = cookies();
     const supabase = createServerClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -130,35 +134,38 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
         },
       }
     );
-    
+
     // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const pageId = resolvedParams.id;
+    const pageId = params.id;
     const body = await request.json();
-    
+
     console.log('Received theme config body:', JSON.stringify(body, null, 2));
-    
+
     try {
       const validatedData = ThemeConfigSchema.parse(body);
       console.log('Theme config validation successful:', validatedData);
     } catch (validationError) {
       console.error('Theme config validation failed:', validationError);
       return NextResponse.json(
-        { 
+        {
           error: 'Invalid theme configuration',
-          details: validationError instanceof z.ZodError ? validationError.errors : validationError
+          details:
+            validationError instanceof z.ZodError
+              ? validationError.errors
+              : validationError,
         },
         { status: 400 }
       );
     }
-    
+
     const validatedData = ThemeConfigSchema.parse(body);
 
     // Verify user owns this link page
@@ -177,8 +184,9 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
     }
 
     // Update the link page with new theme configuration
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const updateData: any = {
-      updated_at: new Date().toISOString()
+      updated_at: new Date().toISOString(),
     };
 
     // Store the complete theme config
@@ -221,9 +229,8 @@ export async function PUT(request: NextRequest, { params }: RouteParams) {
 
     return NextResponse.json({
       data: updatedPage,
-      success: true
+      success: true,
     });
-
   } catch (error) {
     if (error instanceof z.ZodError) {
       return NextResponse.json(
@@ -255,14 +262,14 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         },
       }
     );
-    
+
     // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
     if (authError || !user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const pageId = params.id;
@@ -289,7 +296,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         .select('id')
         .eq('id', userThemeId)
         .eq('user_id', user.id)
-        .single()
+        .single(),
     ]);
 
     if (pageResult.error || !pageResult.data) {
@@ -311,7 +318,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       .from('link_pages')
       .update({
         user_theme_id: userThemeId,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
       })
       .eq('id', pageId)
       .eq('user_id', user.id)
@@ -328,9 +335,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     return NextResponse.json({
       data: updatedPage,
-      success: true
+      success: true,
     });
-
   } catch (error) {
     console.error('Error in PATCH /api/link-pages/[id]/theme:', error);
     return NextResponse.json(
@@ -338,4 +344,4 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       { status: 500 }
     );
   }
-} 
+}


### PR DESCRIPTION
## Summary
- use `cookies()` synchronously
- reference `params` directly and silence eslint for `any` types

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_688cd9597cb88325817271c454cbeef1